### PR TITLE
Fix typo in `discord.iconMap` configuration description

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
               ".lua": "lua",
               ".vue": "vue"
             },
-            "description": "THe icon map for the extension"
+            "description": "The icon map for the extension"
           },
           "discord.interval": {
             "type": "int",


### PR DESCRIPTION
The description of the `discord.iconMap` configuration started with 'THe'. I changed it to 'The'.
You're welcome B)